### PR TITLE
Throw descriptive error

### DIFF
--- a/extends/Animation.js
+++ b/extends/Animation.js
@@ -557,6 +557,10 @@ Example :
 				
 				var seq = self._animations[self._seq], loop = self._loop == "loop";
 				
+				if (!seq) {
+					throw new Error('No animation of type ' + self._seq + ' found');
+				}
+
 				function seqSize(img) {
 					if (seq.size) return seq.size;
 					var data_img = Global_CE.Materials.get(img);


### PR DESCRIPTION
If the coder is trying to start an animation that hasn't been created, this will throw a proper error instead of dying on `if (freq >= seq.frequence) {`
